### PR TITLE
Forgot version bump to 0.2.6 pre-tag, bump to 0.2.7 for new tag

### DIFF
--- a/responsys/__init__.py
+++ b/responsys/__init__.py
@@ -1,4 +1,4 @@
 """Python client library for the Responsys Interact API"""
 
-__version__ = "0.2.5"
+__version__ = "0.2.7"
 __keywords__ = "responsys interact client api"


### PR DESCRIPTION
Forgot to bump version pre 0.2.6 tag, now releasing 0.2.7
